### PR TITLE
Remove deprecated julia keyword in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/giordano/LombScargle.jl.git",
+    repo = "github.com/JuliaAstro/LombScargle.jl.git",
     target = "build",
     deps = nothing,
     make = nothing,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,5 +11,4 @@ deploydocs(
     target = "build",
     deps = nothing,
     make = nothing,
-    julia  = "0.6",
 )


### PR DESCRIPTION
This should hopefully repair the deployment of the docs. 
They failed silently due to changes to Documenter.jl