### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 FFTW = "0.2.3, 0.3, 1"
 Measurements = "1, 2"
-SpecialFunctions = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 1.0"
+SpecialFunctions = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 1.0, 2"
 StableRNGs = "0.1, 1"
 julia = "1"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.